### PR TITLE
Added cancelation token to network listener

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -153,4 +153,9 @@ public class GameManager : MonoBehaviour
             Debug.Log("Trying to destroy entity ID: " + entityID + ", but couldn't find it.");
         }
     }
+
+    public void OnDestroy()
+    {
+        NetworkClient.GetInstance().Destroy();
+    }
 }


### PR DESCRIPTION
Fixes the issue of the listener task continuing to run even after exiting the game in the Unity Editor.